### PR TITLE
Fixing refiner_network to work correctly with multichannel images

### DIFF
--- a/sim-gan.py
+++ b/sim-gan.py
@@ -81,7 +81,7 @@ def refiner_network(input_image_tensor):
 
     # the output of the last ResNet block is passed to a 1 × 1 convolutional layer producing 1 feature map
     # corresponding to the refined synthetic image
-    return layers.Convolution2D(1, 1, 1, border_mode='same', activation='tanh')(x)
+    return layers.Convolution2D(img_channels, 1, 1, border_mode='same', activation='tanh')(x)
 
 
 def discriminator_network(input_image_tensor):


### PR DESCRIPTION
changing the convolution output of the refiner network to match image channels rather than 1.